### PR TITLE
Remove socket's "Where are my headers" ambiguous info

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -917,22 +917,6 @@ defmodule Phoenix.Endpoint do
         ]
   ```
 
-  > #### Where are my headers? {: .tip}
-  >
-  > Phoenix only gives you limited access to the connection headers for security
-  > reasons. WebSockets are cross-domain, which means that, when a user "John Doe"
-  > visits a malicious website, the malicious website can open up a WebSocket
-  > connection to your application, and the browser will gladly submit John Doe's
-  > authentication/cookie information. If you were to accept this information as is,
-  > the malicious website would have full control of a WebSocket connection to your
-  > application, authenticated on John Doe's behalf.
-  >
-  > To safe-guard your application, Phoenix limits and validates the connection
-  > information your socket can access. This means your application is safe from
-  > these attacks, but you can't access cookies and other headers in your socket.
-  > You may access the session stored in the connection via the `:connect_info`
-  > option, provided you also pass a csrf token when connecting over WebSocket.
-
   ## Websocket configuration
 
   The following configuration applies only to `:websocket`.


### PR DESCRIPTION
This PR proposes removing socket's CSWSH-related information

## Context

I'm working on [caching Liveviews](https://svground.fr/blog/posts/caching-liveviews-part-1/) and I've reviewed Websocket's security model.

As far as I understand, there are 2 mechanisms to protect against CSWSH:
- checking the origin
- using a CSRF token

Phoenix implement both.

## The problem

It seems to me that the proposed for deletion section introduced in 2df444bdf7b0fc848704457891e77a3a15218bfa has the following problems:

> WebSockets are cross-domain, which means that, when a user "John Doe" visits a malicious website, the malicious website can open up a WebSocket connection to your application, and the browser will gladly submit John Doe's authentication/cookie information. If you were to accept this information as is, the malicious website would have full control of a WebSocket connection to your application, authenticated on John Doe's behalf.

It's true only if `check_origin` is set to `false`, which is strongly discouraged a few lines above ("If false and you do not validate the session in your socket, your app is vulnerable to Cross-Site WebSocket Hijacking (CSWSH) attacks. Only use in development, when the host is truly unknown or when serving clients that do not send the origin header, such as mobile apps.").

> To safe-guard your application, Phoenix limits and validates the connection information your socket can access. This means your application is safe from these attacks, but you can't access cookies

Actually, when the CSRF token is checked, it means there was no CSWSH (even if `check_origin` is set to `false`) and as a consequence accessing the cookie would be safe.

## Summary

As far as I understand, only in the case when `check_origin` is set to `false` (strongly discouraged, default to `true`) **and** the `:session` is not set in the `:connect_info` of the transport (this is set by default) accessing the cookie header (and only this one) would result in risk of CSWSH.

## Proposed solution

1: delete this section in full
2. rephrase, for instance:

> TBC